### PR TITLE
Treat TypeScript interface as class for purposes of linting

### DIFF
--- a/lib/common/getExportedClass.js
+++ b/lib/common/getExportedClass.js
@@ -5,13 +5,13 @@ module.exports = function getExportedClass(programNode, context) {
 
         // export default ...
         if (node.type === "ExportDefaultDeclaration") {
-            if (node.declaration.type === 'ClassDeclaration' || node.declaration.type === 'ClassExpression') {
+            if (node.declaration.type === 'ClassDeclaration' || node.declaration.type === 'ClassExpression' || node.declaration.type === 'TSInterfaceDeclaration') {
                 return node.declaration;
             }
         }
 
         if (node.type === "ExportNamedDeclaration" && node.declaration) {
-            if (node.declaration.type === 'ClassDeclaration') {
+            if (node.declaration.type === 'ClassDeclaration' || node.declaration.type === 'TSInterfaceDeclaration') {
                 namedExportClasses.push(node.declaration);
             }
         }


### PR DESCRIPTION
This allows us to name files like BlahInterface.ts when they export an interface